### PR TITLE
pin Unison to 2.40, rationale in description

### DIFF
--- a/fs/Dockerfile
+++ b/fs/Dockerfile
@@ -1,6 +1,6 @@
 FROM gansbrest/ubuntu-base
 
-RUN apt-get install unison
+RUN apt-get install unison=2.40.102-2ubuntu1
 
 CMD ["unison", "-socket", "45678"]
 


### PR DESCRIPTION
Even though this is the only version available for `apt-get` on Ubuntu 14.04 base image, when installing unison via homebrew on OS X, a newer version (2.48) breaks compatibility and unison will refuse to connect. Since I presume this Dockerfile is primarily intended to be part of the author's [hodor](https://github.com/gansbrest/hodor) project, I also submitted a [PR there](https://github.com/gansbrest/hodor/pull/18) to install unison 2.40 pin via `brew install homebrew/versions/unison240` in that project's README.md as well.
